### PR TITLE
Fix typo in Perl version

### DIFF
--- a/lib/Attribute/Default.pm
+++ b/lib/Attribute/Default.pm
@@ -8,7 +8,7 @@ package Attribute::Default;
 #### See perldoc for details.
 ####
 
-use 5.0010;
+use 5.010;
 use strict;
 use warnings;
 no warnings 'redefine';


### PR DESCRIPTION
5.010 is v5.1 not v5.10